### PR TITLE
Refine iOS note list edge-to-edge layout

### DIFF
--- a/shared/src/commonMain/kotlin/com/edufelip/shared/ui/components/molecules/notes/NoteRow.kt
+++ b/shared/src/commonMain/kotlin/com/edufelip/shared/ui/components/molecules/notes/NoteRow.kt
@@ -27,6 +27,7 @@ import com.edufelip.shared.resources.updated_hours_ago
 import com.edufelip.shared.resources.updated_just_now
 import com.edufelip.shared.resources.updated_minutes_ago
 import com.edufelip.shared.ui.util.nowEpochMs
+import com.edufelip.shared.ui.util.platform.PlatformFlags
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
@@ -36,17 +37,13 @@ fun NoteRow(
     onClick: (Note) -> Unit = {},
     showUpdated: Boolean = true,
 ) {
-    ElevatedCard(
-        modifier = modifier
-            .fillMaxWidth()
-            .clickable { onClick(note) },
-        elevation = CardDefaults.elevatedCardElevation(defaultElevation = 1.dp),
-        colors = CardDefaults.elevatedCardColors(containerColor = MaterialTheme.colorScheme.surface),
-    ) {
+    val cupertinoLook = PlatformFlags.cupertinoLookEnabled
+    if (cupertinoLook) {
         Column(
-            modifier = Modifier
+            modifier = modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp, vertical = 12.dp)
+                .clickable { onClick(note) }
+                .padding(horizontal = 20.dp, vertical = 16.dp)
                 .animateContentSize(),
             verticalArrangement = Arrangement.spacedBy(6.dp),
         ) {
@@ -58,7 +55,7 @@ fun NoteRow(
             )
             Text(
                 text = relativeTimeAgo(if (showUpdated) note.updatedAt else note.createdAt, showUpdated),
-                style = MaterialTheme.typography.labelSmall,
+                style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             if (note.description.isNotBlank()) {
@@ -68,6 +65,42 @@ fun NoteRow(
                     maxLines = 4,
                     overflow = TextOverflow.Ellipsis,
                 )
+            }
+        }
+    } else {
+        ElevatedCard(
+            modifier = modifier
+                .fillMaxWidth()
+                .clickable { onClick(note) },
+            elevation = CardDefaults.elevatedCardElevation(defaultElevation = 1.dp),
+            colors = CardDefaults.elevatedCardColors(containerColor = MaterialTheme.colorScheme.surface),
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 12.dp)
+                    .animateContentSize(),
+                verticalArrangement = Arrangement.spacedBy(6.dp),
+            ) {
+                Text(
+                    text = note.title,
+                    style = MaterialTheme.typography.titleMedium,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    text = relativeTimeAgo(if (showUpdated) note.updatedAt else note.createdAt, showUpdated),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                if (note.description.isNotBlank()) {
+                    Text(
+                        text = note.description,
+                        style = MaterialTheme.typography.bodyMedium,
+                        maxLines = 4,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- adjust the note list scaffold to honor the Cupertino look with edge-to-edge padding, updated top bar colors, and inline separators on iOS
- restyle note rows on iOS to drop cards in favor of full-width rows while keeping Material cards on other platforms

## Testing
- ./gradlew spotlessApply *(fails: missing ktlint repository)*

------
https://chatgpt.com/codex/tasks/task_e_69040a2ea054833299d95f766d0e9167