### PR TITLE
Refine iOS edge-to-edge scaffolds

### DIFF
--- a/shared/src/commonMain/kotlin/com/edufelip/shared/ui/AmazingNoteApp.kt
+++ b/shared/src/commonMain/kotlin/com/edufelip/shared/ui/AmazingNoteApp.kt
@@ -485,7 +485,11 @@ fun AmazingNoteApp(
             ) {
                 Scaffold(
                     containerColor = Color.Transparent,
-                    contentWindowInsets = WindowInsets.safeDrawing,
+                    contentWindowInsets = if (PlatformFlags.isIos) {
+                        WindowInsets(0)
+                    } else {
+                        WindowInsets.safeDrawing
+                    },
                     topBar = topBarComposable,
                     bottomBar = {
                         if (bottomBarEnabled) {

--- a/shared/src/commonMain/kotlin/com/edufelip/shared/ui/features/auth/screens/LoginScreen.kt
+++ b/shared/src/commonMain/kotlin/com/edufelip/shared/ui/features/auth/screens/LoginScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -35,6 +36,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
@@ -79,6 +81,7 @@ import com.edufelip.shared.resources.password
 import com.edufelip.shared.resources.reset_email_sent
 import com.edufelip.shared.resources.sign_up_success
 import com.edufelip.shared.ui.vm.AuthViewModel
+import com.edufelip.shared.ui.util.platform.PlatformFlags
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
@@ -141,6 +144,11 @@ fun LoginScreen(
     Scaffold(
         containerColor = MaterialTheme.colorScheme.background,
         snackbarHost = { SnackbarHost(snackbarHostState) },
+        contentWindowInsets = if (PlatformFlags.isIos) {
+            WindowInsets(0)
+        } else {
+            ScaffoldDefaults.contentWindowInsets
+        },
     ) { padding ->
         Column(
             modifier = Modifier

--- a/shared/src/commonMain/kotlin/com/edufelip/shared/ui/features/auth/screens/SignUpScreen.kt
+++ b/shared/src/commonMain/kotlin/com/edufelip/shared/ui/features/auth/screens/SignUpScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -28,6 +29,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -63,6 +65,7 @@ import com.edufelip.shared.resources.sign_up_subtitle
 import com.edufelip.shared.resources.sign_up_title
 import com.edufelip.shared.ui.preview.DevicePreviewContainer
 import com.edufelip.shared.ui.preview.DevicePreviews
+import com.edufelip.shared.ui.util.platform.PlatformFlags
 import org.jetbrains.compose.resources.stringResource
 import com.edufelip.shared.preview.Preview
 import com.edufelip.shared.preview.PreviewParameter
@@ -88,6 +91,11 @@ fun SignUpScreen(
 
     Scaffold(
         containerColor = MaterialTheme.colorScheme.background,
+        contentWindowInsets = if (PlatformFlags.isIos) {
+            WindowInsets(0)
+        } else {
+            ScaffoldDefaults.contentWindowInsets
+        },
     ) { padding ->
         Column(
             modifier = Modifier

--- a/shared/src/commonMain/kotlin/com/edufelip/shared/ui/features/notes/components/ListScreen.kt
+++ b/shared/src/commonMain/kotlin/com/edufelip/shared/ui/features/notes/components/ListScreen.kt
@@ -117,6 +117,11 @@ fun ListScreen(
                                     navigationIconContentColor = MaterialTheme.colorScheme.onSurface,
                                     titleContentColor = MaterialTheme.colorScheme.onSurface,
                                 ),
+                                windowInsets = if (PlatformFlags.isIos) {
+                                    WindowInsets(0)
+                                } else {
+                                    TopAppBarDefaults.windowInsets
+                                },
                             )
                         }
                         )

--- a/shared/src/commonMain/kotlin/com/edufelip/shared/ui/features/notes/screens/FolderDetailScreen.kt
+++ b/shared/src/commonMain/kotlin/com/edufelip/shared/ui/features/notes/screens/FolderDetailScreen.kt
@@ -3,6 +3,7 @@ package com.edufelip.shared.ui.features.notes.screens
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -18,6 +19,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
@@ -42,6 +44,7 @@ import com.edufelip.shared.resources.folder_options_rename
 import com.edufelip.shared.ui.features.notes.components.ListScreen
 import com.edufelip.shared.ui.features.notes.dialogs.DeleteFolderDialog
 import com.edufelip.shared.ui.features.notes.dialogs.FolderNameDialog
+import com.edufelip.shared.ui.util.platform.PlatformFlags
 import org.jetbrains.compose.resources.stringResource
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -76,6 +79,11 @@ fun FolderDetailScreen(
 
     Scaffold(
         modifier = modifier.fillMaxSize(),
+        contentWindowInsets = if (PlatformFlags.isIos) {
+            WindowInsets(0)
+        } else {
+            ScaffoldDefaults.contentWindowInsets
+        },
         topBar = {
             TopAppBar(
                 title = { Text(text = title) },
@@ -117,6 +125,11 @@ fun FolderDetailScreen(
                     navigationIconContentColor = MaterialTheme.colorScheme.onSurface,
                     titleContentColor = MaterialTheme.colorScheme.onSurface,
                 ),
+                windowInsets = if (PlatformFlags.isIos) {
+                    WindowInsets(0)
+                } else {
+                    TopAppBarDefaults.windowInsets
+                },
             )
         },
         floatingActionButton = {

--- a/shared/src/commonMain/kotlin/com/edufelip/shared/ui/features/settings/screens/PrivacyScreen.kt
+++ b/shared/src/commonMain/kotlin/com/edufelip/shared/ui/features/settings/screens/PrivacyScreen.kt
@@ -1,6 +1,7 @@
 package com.edufelip.shared.ui.features.settings.screens
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
@@ -9,6 +10,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.material3.Surface
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
@@ -18,6 +20,7 @@ import androidx.compose.ui.unit.dp
 import com.edufelip.shared.resources.Res
 import com.edufelip.shared.resources.privacy_policy
 import com.edufelip.shared.ui.util.Constants
+import com.edufelip.shared.ui.util.platform.PlatformFlags
 import com.edufelip.shared.ui.web.WebView
 import org.jetbrains.compose.resources.stringResource
 
@@ -29,6 +32,11 @@ fun PrivacyScreen(
     onBack: () -> Unit,
 ) {
     Scaffold(
+        contentWindowInsets = if (PlatformFlags.isIos) {
+            WindowInsets(0)
+        } else {
+            ScaffoldDefaults.contentWindowInsets
+        },
         topBar = {
             Surface(tonalElevation = 2.dp, shadowElevation = 1.dp) {
                 TopAppBar(
@@ -43,6 +51,11 @@ fun PrivacyScreen(
                         navigationIconContentColor = androidx.compose.material3.MaterialTheme.colorScheme.onSecondaryContainer,
                         titleContentColor = androidx.compose.material3.MaterialTheme.colorScheme.onSecondaryContainer,
                     ),
+                    windowInsets = if (PlatformFlags.isIos) {
+                        WindowInsets(0)
+                    } else {
+                        TopAppBarDefaults.windowInsets
+                    },
                 )
             }
         },

--- a/shared/src/commonMain/kotlin/com/edufelip/shared/ui/features/trash/screens/TrashScreen.kt
+++ b/shared/src/commonMain/kotlin/com/edufelip/shared/ui/features/trash/screens/TrashScreen.kt
@@ -2,6 +2,7 @@ package com.edufelip.shared.ui.features.trash.screens
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -10,6 +11,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
@@ -24,6 +26,7 @@ import com.edufelip.shared.resources.trash_count
 import com.edufelip.shared.ui.components.organisms.trash.TrashTimeline
 import com.edufelip.shared.ui.preview.DevicePreviewContainer
 import com.edufelip.shared.ui.preview.DevicePreviews
+import com.edufelip.shared.ui.util.platform.PlatformFlags
 import org.jetbrains.compose.resources.stringResource
 import com.edufelip.shared.preview.Preview
 import com.edufelip.shared.preview.PreviewParameter
@@ -40,6 +43,11 @@ fun TrashScreen(
 ) {
     Scaffold(
         modifier = modifier,
+        contentWindowInsets = if (PlatformFlags.isIos) {
+            WindowInsets(0)
+        } else {
+            ScaffoldDefaults.contentWindowInsets
+        },
         topBar = {
             TopAppBar(
                 title = {
@@ -68,6 +76,11 @@ fun TrashScreen(
                     navigationIconContentColor = MaterialTheme.colorScheme.onSurface,
                     titleContentColor = MaterialTheme.colorScheme.onSurface,
                 ),
+                windowInsets = if (PlatformFlags.isIos) {
+                    WindowInsets(0)
+                } else {
+                    TopAppBarDefaults.windowInsets
+                },
             )
         },
     ) { padding ->


### PR DESCRIPTION
## Summary
- remove default safe-area padding from the shared app scaffold when running on iOS so content can draw edge-to-edge
- align list, folder detail, trash, privacy, and auth screens with zero window insets on iOS and keep default handling elsewhere

## Testing
- ./gradlew :shared:check *(fails: missing Android SDK in CI image)*

------
https://chatgpt.com/codex/tasks/task_e_69040a2ea054833299d95f766d0e9167